### PR TITLE
Increase ZiGX token max supply to 1 billion

### DIFF
--- a/ZiGX_Advanced_MainnetFinal.sol
+++ b/ZiGX_Advanced_MainnetFinal.sol
@@ -12,7 +12,7 @@ interface IReserveOracle {
 
 contract ZiGX is ERC20 {
     uint8 private constant CUSTOM_DECIMALS = 6;
-    uint256 public constant MAX_SUPPLY = 100_000_000 * 10 ** CUSTOM_DECIMALS;
+    uint256 public constant MAX_SUPPLY = 1_000_000_000 * 10 ** CUSTOM_DECIMALS;
     uint256 public constant RESERVE_LOCK_UNTIL = 1_735_689_600; // Jan 1, 2030 UTC
 
     address public governance; // Gnosis Safe


### PR DESCRIPTION
## Summary
- update the ZiGX MAX_SUPPLY constant to target a 1,000,000,000 token cap while preserving custom decimals

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d644b33170832a86d4d568b51d0059